### PR TITLE
Masquerade heartbeat fix

### DIFF
--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -86,6 +86,10 @@
 			if(M.stat == DEAD && heart && world.time - M.timeofdeath < DEFIB_TIME_LIMIT * 10)
 				heart_strength = "<span class='boldannounce'>a faint, fluttery</span>"
 
+			if(heart && istype(heart,/obj/item/organ/heart/vampheart/)) // austation begin -- Blooduscker integration
+				var/obj/item/organ/heart/vampheart/vampheart = heart
+				heart_strength = vampheart.HeartStrengthMessage() // austation end
+
 			var/diagnosis = (body_part == BODY_ZONE_CHEST ? "You hear [heart_strength] pulse and [lung_strength] respiration." : "You faintly hear [heart_strength] pulse.")
 			user.visible_message("[user] places [src] against [M]'s [body_part] and listens attentively.", "<span class='notice'>You place [src] against [M]'s [body_part]. [diagnosis]</span>")
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Masquerading Bloodsuckers weren't safe from an ancient and un(der)used tool called stethoscope. I fixed it. More technically, masquerading bloodsuckers should be seen having a normal heart, and non-masquerading bloodsuckers should be seen having no heartbeat; it is what fulp coders envisioned when coding bloodsuckers... at least Swain did this way.

## Why It's Good For The Game

We fucking can't modularize /obj/item/clothing/neck/stethoscope/attack because it isn't /obj/item/clothing/neck/stethoscope**/proc**/attack, so I had to do this. Hope Terra won't bonk this. I tried this to be as un-invasive as possible by making this fix addition-only. Additionally, we might have to tweak /obj/item/organ/heart/vampheart/HeartStrengthMessage() a little, but, hey, I am too lazy for that.

I am pretty sure that almost no one will use stethoscope anyway, but guess it is a matter of time for people to discover that they can reliably distinguish bloodsuckers using stethoscopes, but they shouldn't.

## Changelog
:cl:
fix: Now Bloodsuckers are safe from stethoscopes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
